### PR TITLE
[#121003303] Changes for OSX Concourse Pipeline

### DIFF
--- a/concourse/build_osx_debug.yml
+++ b/concourse/build_osx_debug.yml
@@ -10,3 +10,4 @@ run:
   - gpos_src/concourse/build_and_test.py
   - --build_type=DEBUG
   - --output_dir=build_and_test_osx_debug/install
+  - --32=True

--- a/concourse/publish_tag.bash
+++ b/concourse/publish_tag.bash
@@ -7,12 +7,14 @@ set -u -e -x
 main() {
   local INPUT_RLS_DIR=bin_gpos_release
   local INPUT_DBG_DIR=bin_gpos_debug
-  local INPUT_OSX_DIR=bin_gpos_osx_release
+  local INPUT_OSX_RLS_DIR=bin_gpos_osx_release
+  local INPUT_OSX_DBG_DIR=bin_gpos_osx_debug
   local OUTPUT_DIR=gpos_github_release_stage
   env LC_ALL=C tar tf $INPUT_RLS_DIR/*.tar.gz | grep "libgpos.so." | sort -n | head -n 1 | sed 's/\.\/lib\/libgpos\.so\./v/' > $OUTPUT_DIR/tag.txt
   cp -v $INPUT_RLS_DIR/*.tar.gz $OUTPUT_DIR/
   cp -v $INPUT_DBG_DIR/*.tar.gz $OUTPUT_DIR/
-  cp -v $INPUT_OSX_DIR/*.tar.gz $OUTPUT_DIR/
+  cp -v $INPUT_OSX_RLS_DIR/*.tar.gz $OUTPUT_DIR/
+  cp -v $INPUT_OSX_DBG_DIR/*.tar.gz $OUTPUT_DIR/
   env GIT_DIR=gpos_src/.git git rev-parse HEAD > $OUTPUT_DIR/commit.txt
 }
 

--- a/concourse/publish_tag.yml
+++ b/concourse/publish_tag.yml
@@ -5,6 +5,7 @@ inputs:
   - name: bin_gpos_release
   - name: bin_gpos_debug
   - name: bin_gpos_osx_release
+  - name: bin_gpos_osx_debug
 outputs:
   - name: gpos_github_release_stage
 run:


### PR DESCRIPTION
- create YAML files for OSX pipeline
- fix existing files to use /usr/bin/python instead of /usr/bin/python2,
  because it is missing on OSX (python2 is symlink to python on CentOS)
- fix a warning in CAutoTaskProxyTest.cpp, which was breaking the
  Release build