### PR TITLE
Add a config.h, containing GPOS_DEBUG and other flags that affect ABI.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -159,6 +159,13 @@ include_directories(libgpos/include)
 configure_file(version.h.in
                ${PROJECT_BINARY_DIR}/libgpos/include/gpos/version.h)
 
+configure_file(config.h.in
+               ${PROJECT_BINARY_DIR}/libgpos/include/gpos/config.h)
+
+
+# for the generated version.h and config.h files.
+include_directories(${PROJECT_BINARY_DIR}/libgpos/include/)
+
 # Compile .cpp source files under libgpos/src into monolithic gpos library.
 add_library(gpos SHARED
             libgpos/include/gpos/assert.h
@@ -439,11 +446,15 @@ if (VERBOSE_INSTALL_PATH)
   install(DIRECTORY libgpos/include/gpos DESTINATION "${installpath}/include")
   install(FILES "${PROJECT_BINARY_DIR}/libgpos/include/gpos/version.h"
           DESTINATION "${installpath}/include/gpos")
+  install(FILES "${PROJECT_BINARY_DIR}/libgpos/include/gpos/config.h"
+          DESTINATION "${installpath}/include/gpos")
 else()
   get_filename_component(full_install_name_dir "${CMAKE_INSTALL_PREFIX}/lib" ABSOLUTE)
   install(TARGETS gpos DESTINATION lib)
   install(DIRECTORY libgpos/include/gpos DESTINATION include)
   install(FILES "${PROJECT_BINARY_DIR}/libgpos/include/gpos/version.h"
+          DESTINATION include/gpos)
+  install(FILES "${PROJECT_BINARY_DIR}/libgpos/include/gpos/config.h"
           DESTINATION include/gpos)
 endif()
 

--- a/config.h.in
+++ b/config.h.in
@@ -1,0 +1,29 @@
+//---------------------------------------------------------------------------
+//	Greenplum Database
+//	Copyright (C) 2016 Greenplum, Inc.
+//
+//	@filename:
+//		config.h
+//
+//	@doc:
+//		Various compile-time options that affect binary
+//		compatibility.
+//
+//---------------------------------------------------------------------------
+#ifndef GPOS_config_H
+#define GPOS_config_H
+
+#cmakedefine GPOS_DEBUG
+
+// These come from CMAKE_SYSTEM_PROCESSOR
+#cmakedefine GPOS_i386
+#cmakedefine GPOS_i686
+#cmakedefine GPOS_x86_64
+#cmakedefine GPOS_sparc
+
+// These come from CMAKE_ARCH_BITS (based on CMAKE_SIZEOF_VOID_P)
+#cmakedefine GPOS_32BIT
+#cmakedefine GPOS_64BIT
+
+#endif  // GPOS_config_H
+// EOF

--- a/libgpos/include/gpos/_api.h
+++ b/libgpos/include/gpos/_api.h
@@ -17,6 +17,8 @@
 #ifndef GPOS_api_H
 #define GPOS_api_H
 
+#include "gpos/config.h"
+
 #ifdef __cplusplus
 extern "C"
 {

--- a/libgpos/include/gpos/assert.h
+++ b/libgpos/include/gpos/assert.h
@@ -22,6 +22,7 @@
 #ifndef GPOS_assert_H
 #define GPOS_assert_H
 
+#include "gpos/config.h"
 
 // retail assert; available in all builds
 #define GPOS_RTL_ASSERT(x)		((x) ? ((void)0) : \


### PR DESCRIPTION
Before this patch, consumers of libgpos had to know out-of-band which
flags were used to compile libgpos, because e.g. libgpos compiled with
GPOS_DEBUG would only work if the application using libgpos was also
compiled with GPOS_DEBUG. This is because many of the structs differ
depending on GPOS_DEBUG. Same for the architecture flags, like GPOS_i386.

The new config.h file is #included from a few central other header files,
to make sure it gets included in any application that uses other gpos
headers. We probably should include config.h from *all* other gpos header
files, to be sure, but this seems to be enough for ORCA and GPDB at least.