### PR TITLE
Fix GPDB/GPOS crash in debug builds

### DIFF
--- a/libgpos/include/gpos/sync/CSpinlock.inl
+++ b/libgpos/include/gpos/sync/CSpinlock.inl
@@ -48,7 +48,7 @@ namespace gpos
 	CSpinlockRanked<ulRank>::Lock()
 	{
 #ifdef GPOS_DEBUG
-		GPOS_ASSERT_IMP(0 < ulRank, 
+		GPOS_ASSERT_IMP(0 < ulRank && IWorker::PwrkrSelf(),
 			IWorker::PwrkrSelf()->FCanAcquireSpinlock(this) && 
 			"Tried to acquire spinlock in incorrect order or detected deadlock.");
 #endif // GPOS_DEBUG
@@ -104,7 +104,7 @@ namespace gpos
 		gpos::UlpExchangeAdd(&m_ulpCollisions, ulAttempts);
 
 #ifdef GPOS_DEBUG
-		if (0 < ulRank)
+		if (0 < ulRank && NULL != IWorker::PwrkrSelf())
 		{
 			IWorker::PwrkrSelf()->RegisterSpinlock(this);
 		}
@@ -128,7 +128,7 @@ namespace gpos
 	CSpinlockRanked<ulRank>::Unlock()
 	{
 #ifdef GPOS_DEBUG		
-		if (0 < ulRank)
+		if (0 < ulRank && NULL != IWorker::PwrkrSelf())
 		{
 			IWorker::PwrkrSelf()->UnregisterSpinlock(this);
 		}


### PR DESCRIPTION
In Debug builds of GPDB, we try and shutdown the MDCache manually from TerminateGPOPT. Accessing the SyncHashTable of the MDCache rquires acquiring a spln lock, and to acquire that spin lock, we need a PwrkSelf() worker object to make sure we don't deadlock etc. However at this point all workers (created during OptimizerQuery) have been cleaned up, and so ``` IWorker::PwrkrSelf()``` returns NULL. This check is mute if there is no worker, so we should guard against that case.

@d Please have a look. 