### PR TITLE
Add a config.h, containing GPOS_DEBUG and other flags that affect ABI.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,13 +108,6 @@ set_property(
     DIRECTORY
     APPEND PROPERTY COMPILE_DEFINITIONS $<$<CONFIG:Debug>:GPOS_DEBUG>)
 
-# Turn on platform-specific defines.
-set_property(
-    DIRECTORY
-    APPEND PROPERTY COMPILE_DEFINITIONS
-        GPOS_${CMAKE_SYSTEM_NAME}
-        GPOS_${CMAKE_SYSTEM_PROCESSOR})
-
 # Autodetect bit-width if not already set by toolchain file.
 if (NOT GPOS_ARCH_BITS)
   # Autodetect bit-width.
@@ -132,11 +125,6 @@ if (NOT GPOS_ARCH_BITS)
     message(FATAL_ERROR "Could not detect 32-bit OR 64-bit architecture")
   endif()
 endif()
-
-set_property(
-    DIRECTORY
-    APPEND PROPERTY COMPILE_DEFINITIONS
-        GPOS_${GPOS_ARCH_BITS}BIT)
 
 # Need pthreads.
 find_package(Threads REQUIRED)
@@ -158,9 +146,14 @@ endif()
 
 include_directories(libgpos/include)
 
-# Generate version-number header.
+# Generate version-number and config headers.
 configure_file(version.h.in
                ${PROJECT_BINARY_DIR}/libgpos/include/gpos/version.h)
+configure_file(config.h.in
+               ${PROJECT_BINARY_DIR}/libgpos/include/gpos/config.h)
+
+# Make the generated header files available at compilation of libgpos itself.
+include_directories(${PROJECT_BINARY_DIR}/libgpos/include/)
 
 # Compile .cpp source files under libgpos/src into monolithic gpos library.
 add_library(gpos
@@ -432,11 +425,15 @@ if (VERBOSE_INSTALL_PATH)
   install(DIRECTORY libgpos/include/gpos DESTINATION "${installpath}/include")
   install(FILES "${PROJECT_BINARY_DIR}/libgpos/include/gpos/version.h"
           DESTINATION "${installpath}/include/gpos")
+  install(FILES "${PROJECT_BINARY_DIR}/libgpos/include/gpos/config.h"
+          DESTINATION "${installpath}/include/gpos")
 else()
   get_filename_component(full_install_name_dir "${CMAKE_INSTALL_PREFIX}/lib" ABSOLUTE)
   install(TARGETS gpos DESTINATION lib)
   install(DIRECTORY libgpos/include/gpos DESTINATION include)
   install(FILES "${PROJECT_BINARY_DIR}/libgpos/include/gpos/version.h"
+          DESTINATION include/gpos)
+  install(FILES "${PROJECT_BINARY_DIR}/libgpos/include/gpos/config.h"
           DESTINATION include/gpos)
 endif()
 

--- a/config.h.in
+++ b/config.h.in
@@ -1,0 +1,26 @@
+//---------------------------------------------------------------------------
+//	Greenplum Database
+//	Copyright (C) 2016 Greenplum, Inc.
+//
+//	@filename:
+//		config.h
+//
+//	@doc:
+//		Various compile-time options that affect binary
+//		compatibility.
+//
+//---------------------------------------------------------------------------
+#ifndef GPOS_config_H
+#define GPOS_config_H
+
+#cmakedefine GPOS_DEBUG 1
+
+// Thes comes from CMAKE_SYSTEM_NAME and CMAKE_SYSTEM_PROCESSOR
+#define GPOS_${CMAKE_SYSTEM_NAME} 1
+#define GPOS_${CMAKE_SYSTEM_PROCESSOR} 1
+
+// This comes from GPOS_ARCH_BITS (based on CMAKE_SIZEOF_VOID_P)
+#define GPOS_${GPOS_ARCH_BITS}BIT 1
+
+#endif  // GPOS_config_H
+// EOF

--- a/libgpos/include/gpos/_api.h
+++ b/libgpos/include/gpos/_api.h
@@ -17,6 +17,8 @@
 #ifndef GPOS_api_H
 #define GPOS_api_H
 
+#include "gpos/config.h"
+
 #ifdef __cplusplus
 extern "C"
 {

--- a/libgpos/include/gpos/assert.h
+++ b/libgpos/include/gpos/assert.h
@@ -22,6 +22,7 @@
 #ifndef GPOS_assert_H
 #define GPOS_assert_H
 
+#include "gpos/config.h"
 
 // retail assert; available in all builds
 #define GPOS_RTL_ASSERT(x)		((x) ? ((void)0) : \


### PR DESCRIPTION
Before this patch, consumers of libgpos had to know out-of-band which
flags were used to compile libgpos, because e.g. libgpos compiled with
GPOS_DEBUG would only work if the application using libgpos was also
compiled with GPOS_DEBUG. This is because many of the structs differ
depending on GPOS_DEBUG. Same for the architecture flags, like GPOS_i386.

The new config.h file is #included from a few central other header files,
to make sure it gets included in any application that uses other gpos
headers. We probably should include config.h from *all* other gpos header
files, to be sure, but this seems to be enough for ORCA and GPDB at least.